### PR TITLE
Bug: MacOS Startup Handler Conflict

### DIFF
--- a/src/main/components/factory.ts
+++ b/src/main/components/factory.ts
@@ -3,7 +3,9 @@ import * as log from 'electron-log'
 
 export default (namespace) => {
   const handle = (channel, listener) => {
-    ipcMain.handle([namespace, channel].join('-'), async (...parameters) => {
+    const channel_absolute = [namespace, channel].join('-')
+    ipcMain.removeHandler(channel_absolute)
+    ipcMain.handle(channel_absolute, async (...parameters) => {
       const { processId, frameId } = parameters.shift()
       log.info(`Handle ${namespace} ${channel}`, { processId, frameId })
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -98,9 +98,6 @@ class Main {
   }
 
   static register () {
-    log.info('Reset listeners for IPC communication')
-    ipcMain.removeAllListeners()
-
     log.info('Register main process components')
 
     ActionsComponent.register(Main.window)


### PR DESCRIPTION
This PR is intended to address issues with triggered events causing duplicate handler registration on the main process, specifically to address issue #79.